### PR TITLE
Updated Detector.py imports for lib Detector

### DIFF
--- a/lib/Detector.py
+++ b/lib/Detector.py
@@ -1,5 +1,5 @@
 import dlib
-from DetectorResult import DetectorResult
+from lib.DetectorResult import DetectorResult
 from lib.Trainer import DETECTOR_SVM
 from lib.Trainer import PREDICTOR_DAT
 from skimage import io


### PR DESCRIPTION
When trying to build this module without Docker I came across this fix in references to dependencies.

Does this make sense to you? My proposed file change seems to fix the issue.

```python
from DetectorResult import DetectorResult
```

to

```python
from lib.DetectorResult import DetectorResult
```